### PR TITLE
dim contrast (brightness) up after boot (not down)

### DIFF
--- a/alarm-clock-soas.yaml
+++ b/alarm-clock-soas.yaml
@@ -150,7 +150,7 @@ globals:
     initial_value: '0'
   - id: contrast_current
     type: float
-    initial_value: '1.0'
+    initial_value: '0.04'
   - id: contrast_target
     type: float
     initial_value: '1.0'


### PR DESCRIPTION
If clock reboots on alarm and room is dark, you will not be blinded with this change.