### PR TITLE
Rename alarm off button single click time to max min, and lower min to 0,25s instead of 0,5s

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ substitutions:
   alarm_off_button_pin: GPIO4
   rotary_button_pin: GPIO8
   language: "EN" #NL and DE are also supported
-  alarm_off_button_single_click_time: 1s #max time in seconds, which the alarm off button can be pressed to recognize the press
+  alarm_off_button_single_click_time_max: 1s    #max time in seconds, which the alarm off button can be pressed to recognize the press
+  alarm_off_button_single_click_time_min: 0.25s #min time in seconds, which the alarm off button must be pressed to recognize the press
   timezone: Europe/Amsterdam
 
 packages:

--- a/alarm-clock-soas.yaml
+++ b/alarm-clock-soas.yaml
@@ -619,8 +619,8 @@ binary_sensor:
                 - delay: 1s #give the media_player a break
                 - switch.turn_on: music_on
       - timing: #single click
-        - ON for at most ${alarm_off_button_single_click_time}
-        - OFF for at least 0.5s
+        - ON for at most ${alarm_off_button_single_click_time_max}
+        - OFF for at least ${alarm_off_button_single_click_time_min}
         then:
           - script.execute: display_off_script
           - lambda: |-


### PR DESCRIPTION
With my switches, we found the 0,5s min click time for alarm off button to long.
Sometime it does not recognize an single snooze/alarm_off press.
-> The WAF sank, but this brought it back up again ;-)